### PR TITLE
Add vimux vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -752,6 +752,17 @@ rec {
 
   };
 
+  vimux = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vimux-2017-10-24";
+    src = fetchgit {
+      url = "https://github.com/benmills/vimux";
+      rev = "37f41195e6369ac602a08ec61364906600b771f1";
+      sha256 = "0k7ymak2ag67lb4sf80y4k35zj38rj0jf61bf50i6h1bgw987pra";
+    };
+    dependencies = [];
+  };
+
+
   vim-hdevtools = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-hdevtools-2017-03-11";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -12,6 +12,7 @@
 "github:bazelbuild/vim-bazel"
 "github:bbchung/clighter8"
 "github:benekastah/neomake"
+"github:benmills/vimux"
 "github:bitc/vim-hdevtools"
 "github:bronson/vim-trailing-whitespace"
 "github:cespare/vim-toml"


### PR DESCRIPTION
###### Motivation for this change

I use this vim plugin, and noticed it was not in the registry yet.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---